### PR TITLE
Updates:

### DIFF
--- a/includes/api-documentation/api-documentation.js
+++ b/includes/api-documentation/api-documentation.js
@@ -49,7 +49,7 @@ $(function() {
     };
 
     // binding to the body because of ajax refreshing of the page
-    $('#page').on('click', '#doc-sidebar h4', binder(headingClick));
+    $('body').on('click', '#doc-sidebar h4', binder(headingClick));
 
     // look for appearing pre.mdown for code styling
     var CM_MODE_PATH = '/lib/codemirror/mode/',

--- a/includes/api-documentation/api-documentation.php
+++ b/includes/api-documentation/api-documentation.php
@@ -27,7 +27,7 @@
 
 include_once 'lib/markdown/markdown.php';
 
-$template = $template ?: 'website';
+$template = $template ?: 'html5';
 $title = $title ?: 'Developer API';
 
 $this->css[] = '/lib/codemirror/lib/codemirror.css';
@@ -46,12 +46,12 @@ if (!$api) {
 }
 
 $keys = array('protocol', 'domain', 'url');
-$url_prefix = vsprintf(
+$url_prefix = rtrim(vsprintf(
     '%s://%s%s',
     array_filter(array_map(function($k) use($config) {
         return $config['url'][$k];
     }, $keys))
-);
+), '/');
 
 if (!$config || !is_assoc($config) || !$url_prefix) {
     throw new Exception(

--- a/includes/api-documentation/mustache/docs_page.m
+++ b/includes/api-documentation/mustache/docs_page.m
@@ -25,9 +25,15 @@
         <tr>
             <td class="param-type">
                 {{type}}
+                {{^type}}
+                --
+                {{/type}}
             </td>
             <td class="param-name">
                 {{name}}
+                {{^name}}
+                --
+                {{/name}}
             </td>
             <td class="param-description">
                 {{{description}}}


### PR DESCRIPTION
- default template html5
- rtrim config[uri]
- js binding
- if param table does not have type/name show dashes
